### PR TITLE
fix: allow namespaces

### DIFF
--- a/services/bot/.eslintrc.js
+++ b/services/bot/.eslintrc.js
@@ -9,5 +9,6 @@ module.exports = {
 		"@typescript-eslint/explicit-member-accessibility": "off",
 		"@typescript-eslint/no-throw-literal": "off",
 		"@typescript-eslint/method-signature-style": "off",
+		"@typescript-eslint/no-namespace": "off",
 	},
 };

--- a/services/bot/src/lib/internal/structures/modules/Module.ts
+++ b/services/bot/src/lib/internal/structures/modules/Module.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-namespace */
 import { container, Piece } from "@sapphire/framework";
 import { captureException } from "@sentry/node";
 import type { Guild, MessageEmbed } from "discord.js";


### PR DESCRIPTION
Allow namespaces without eslint rule overrides